### PR TITLE
Add Some Double Layer Protection...

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sign in with your Github account and fork this repo.
 * After starting XRDP, copy your project's pulbic IP address and open a remote desktop client.
 * Use the public IP, plus the following credentials to login:
     User: `vcpb`  
-    Passphrase: `music` or the password you set previously
+    Passphrase: `music` or the password you set previously.
 * After logging in, you can ignore some expected error messages.
 * Open Mate terminal, type `~/Telegram/Telegram` to open tdesktop.
 * When tdesktop is opened, login with an alt account of yours.


### PR DESCRIPTION
Creating This Pr only beacuse there is no option for issue and support grp says "offtopic".....Just add any shit protection tonkeep the peoples privacy....... The fault is from both sides that is.... zeet and this repo...... zert gives ppl common public ip and this repo make a default username and password. ......You Should make a change so that its manitory for each person to add a custom username and password..... it just sime as calling vars uaing os...... Just do it and make peoples telegram account safe bruh...... Just few wits will help you....... This is a serious issue to be considered...... many people deploy this repo on zert and they loses there privacy......Adapt some measure dude....Such as making a manitory vars for username and password for prevent another person from logging into another person xrdp telegarm account...  Just fking Add Them Dude.........